### PR TITLE
_locales/: adds translation files and tagline for more languages:

### DIFF
--- a/source/_locales/ar/messages.json
+++ b/source/_locales/ar/messages.json
@@ -1,0 +1,34 @@
+{
+    "appDesc": {
+        "message": "حماية عالية الجودة مجانية لمتصفحك الشخصي.",
+        "description": "The description of the extension, displayed in the user's browser."
+    },
+    "description": {
+        "message": "Free enterprise-grade security for your personal browser.",
+        "description": "The description in the manifest."
+    },
+    "malicious_sites_detected": {
+        "message": "Malicious Sites Detected",
+        "description": "The text used to show how many malicious URLs are scanned on the dashboard."
+    },
+    "popup_title": {
+        "message": "Threatslayer Active.",
+        "description": "The title used for the popup when the extension icon is pressed."
+    },
+    "urls_scanned": {
+        "message": "URLs Scanned",
+        "description": "The text used to show how many URLs are scanned on the dashboard."
+    },
+    "unique_urls_scanned": {
+        "message": "Unique URLs Scanned",
+        "description": "The text used to show how many unique URLs are scanned on the dashboard."
+    },
+    "warning_header": {
+        "message": "THREATSLAYER ALERT!",
+        "description": "The text used in the warning banner."
+    },
+    "warning_text": {
+        "message": "This website may be malicious. Close this tab unless you know the site is safe.",
+        "description": "The text used in the warning banner."
+    }
+}

--- a/source/_locales/de/messages.json
+++ b/source/_locales/de/messages.json
@@ -1,0 +1,34 @@
+{
+    "appDesc": {
+        "message": "Kostenloser Schutz der Enterprise-Klasse für Ihren persönlichen Browser.",
+        "description": "The description of the extension, displayed in the user's browser."
+    },
+    "description": {
+        "message": "Free enterprise-grade security for your personal browser.",
+        "description": "The description in the manifest."
+    },
+    "malicious_sites_detected": {
+        "message": "Malicious Sites Detected",
+        "description": "The text used to show how many malicious URLs are scanned on the dashboard."
+    },
+    "popup_title": {
+        "message": "Threatslayer Active.",
+        "description": "The title used for the popup when the extension icon is pressed."
+    },
+    "urls_scanned": {
+        "message": "URLs Scanned",
+        "description": "The text used to show how many URLs are scanned on the dashboard."
+    },
+    "unique_urls_scanned": {
+        "message": "Unique URLs Scanned",
+        "description": "The text used to show how many unique URLs are scanned on the dashboard."
+    },
+    "warning_header": {
+        "message": "THREATSLAYER ALERT!",
+        "description": "The text used in the warning banner."
+    },
+    "warning_text": {
+        "message": "This website may be malicious. Close this tab unless you know the site is safe.",
+        "description": "The text used in the warning banner."
+    }
+}

--- a/source/_locales/es/messages.json
+++ b/source/_locales/es/messages.json
@@ -1,0 +1,34 @@
+{
+    "appDesc": {
+        "message": "Protección de grado empresarial gratuita para su navegador personal.",
+        "description": "The description of the extension, displayed in the user's browser."
+    },
+    "description": {
+        "message": "Free enterprise-grade security for your personal browser.",
+        "description": "The description in the manifest."
+    },
+    "malicious_sites_detected": {
+        "message": "Malicious Sites Detected",
+        "description": "The text used to show how many malicious URLs are scanned on the dashboard."
+    },
+    "popup_title": {
+        "message": "Threatslayer Active.",
+        "description": "The title used for the popup when the extension icon is pressed."
+    },
+    "urls_scanned": {
+        "message": "URLs Scanned",
+        "description": "The text used to show how many URLs are scanned on the dashboard."
+    },
+    "unique_urls_scanned": {
+        "message": "Unique URLs Scanned",
+        "description": "The text used to show how many unique URLs are scanned on the dashboard."
+    },
+    "warning_header": {
+        "message": "THREATSLAYER ALERT!",
+        "description": "The text used in the warning banner."
+    },
+    "warning_text": {
+        "message": "This website may be malicious. Close this tab unless you know the site is safe.",
+        "description": "The text used in the warning banner."
+    }
+}

--- a/source/_locales/fr/messages.json
+++ b/source/_locales/fr/messages.json
@@ -1,0 +1,34 @@
+{
+    "appDesc": {
+        "message": "Protection professionnelle gratuite pour votre navigateur personnel.",
+        "description": "The description of the extension, displayed in the user's browser."
+    },
+    "description": {
+        "message": "Free enterprise-grade security for your personal browser.",
+        "description": "The description in the manifest."
+    },
+    "malicious_sites_detected": {
+        "message": "Malicious Sites Detected",
+        "description": "The text used to show how many malicious URLs are scanned on the dashboard."
+    },
+    "popup_title": {
+        "message": "Threatslayer Active.",
+        "description": "The title used for the popup when the extension icon is pressed."
+    },
+    "urls_scanned": {
+        "message": "URLs Scanned",
+        "description": "The text used to show how many URLs are scanned on the dashboard."
+    },
+    "unique_urls_scanned": {
+        "message": "Unique URLs Scanned",
+        "description": "The text used to show how many unique URLs are scanned on the dashboard."
+    },
+    "warning_header": {
+        "message": "THREATSLAYER ALERT!",
+        "description": "The text used in the warning banner."
+    },
+    "warning_text": {
+        "message": "This website may be malicious. Close this tab unless you know the site is safe.",
+        "description": "The text used in the warning banner."
+    }
+}

--- a/source/_locales/he/messages.json
+++ b/source/_locales/he/messages.json
@@ -1,0 +1,34 @@
+{
+    "appDesc": {
+        "message": "הגנה ברמת העסקים חופשית עבור הדפדפן האישי שלך.",
+        "description": "The description of the extension, displayed in the user's browser."
+    },
+    "description": {
+        "message": "Free enterprise-grade security for your personal browser.",
+        "description": "The description in the manifest."
+    },
+    "malicious_sites_detected": {
+        "message": "Malicious Sites Detected",
+        "description": "The text used to show how many malicious URLs are scanned on the dashboard."
+    },
+    "popup_title": {
+        "message": "Threatslayer Active.",
+        "description": "The title used for the popup when the extension icon is pressed."
+    },
+    "urls_scanned": {
+        "message": "URLs Scanned",
+        "description": "The text used to show how many URLs are scanned on the dashboard."
+    },
+    "unique_urls_scanned": {
+        "message": "Unique URLs Scanned",
+        "description": "The text used to show how many unique URLs are scanned on the dashboard."
+    },
+    "warning_header": {
+        "message": "THREATSLAYER ALERT!",
+        "description": "The text used in the warning banner."
+    },
+    "warning_text": {
+        "message": "This website may be malicious. Close this tab unless you know the site is safe.",
+        "description": "The text used in the warning banner."
+    }
+}

--- a/source/_locales/hi/messages.json
+++ b/source/_locales/hi/messages.json
@@ -1,0 +1,34 @@
+{
+    "appDesc": {
+        "message": "अपने व्यक्तिगत ब्राउज़र के लिए मुफ्त उद्यम ग्रेड सुरक्षा.",
+        "description": "The description of the extension, displayed in the user's browser."
+    },
+    "description": {
+        "message": "Free enterprise-grade security for your personal browser.",
+        "description": "The description in the manifest."
+    },
+    "malicious_sites_detected": {
+        "message": "Malicious Sites Detected",
+        "description": "The text used to show how many malicious URLs are scanned on the dashboard."
+    },
+    "popup_title": {
+        "message": "Threatslayer Active.",
+        "description": "The title used for the popup when the extension icon is pressed."
+    },
+    "urls_scanned": {
+        "message": "URLs Scanned",
+        "description": "The text used to show how many URLs are scanned on the dashboard."
+    },
+    "unique_urls_scanned": {
+        "message": "Unique URLs Scanned",
+        "description": "The text used to show how many unique URLs are scanned on the dashboard."
+    },
+    "warning_header": {
+        "message": "THREATSLAYER ALERT!",
+        "description": "The text used in the warning banner."
+    },
+    "warning_text": {
+        "message": "This website may be malicious. Close this tab unless you know the site is safe.",
+        "description": "The text used in the warning banner."
+    }
+}

--- a/source/_locales/ja/messages.json
+++ b/source/_locales/ja/messages.json
@@ -1,0 +1,34 @@
+{
+    "appDesc": {
+        "message": "あなたの個人ブラウザ用のフリーエンタープライズグレードの保護.",
+        "description": "The description of the extension, displayed in the user's browser."
+    },
+    "description": {
+        "message": "Free enterprise-grade security for your personal browser.",
+        "description": "The description in the manifest."
+    },
+    "malicious_sites_detected": {
+        "message": "Malicious Sites Detected",
+        "description": "The text used to show how many malicious URLs are scanned on the dashboard."
+    },
+    "popup_title": {
+        "message": "Threatslayer Active.",
+        "description": "The title used for the popup when the extension icon is pressed."
+    },
+    "urls_scanned": {
+        "message": "URLs Scanned",
+        "description": "The text used to show how many URLs are scanned on the dashboard."
+    },
+    "unique_urls_scanned": {
+        "message": "Unique URLs Scanned",
+        "description": "The text used to show how many unique URLs are scanned on the dashboard."
+    },
+    "warning_header": {
+        "message": "THREATSLAYER ALERT!",
+        "description": "The text used in the warning banner."
+    },
+    "warning_text": {
+        "message": "This website may be malicious. Close this tab unless you know the site is safe.",
+        "description": "The text used in the warning banner."
+    }
+}

--- a/source/_locales/ko/messages.json
+++ b/source/_locales/ko/messages.json
@@ -1,0 +1,34 @@
+{
+    "appDesc": {
+        "message": "개인 브라우저용 무료 엔터프라이즈 수준 보호.",
+        "description": "The description of the extension, displayed in the user's browser."
+    },
+    "description": {
+        "message": "Free enterprise-grade security for your personal browser.",
+        "description": "The description in the manifest."
+    },
+    "malicious_sites_detected": {
+        "message": "Malicious Sites Detected",
+        "description": "The text used to show how many malicious URLs are scanned on the dashboard."
+    },
+    "popup_title": {
+        "message": "Threatslayer Active.",
+        "description": "The title used for the popup when the extension icon is pressed."
+    },
+    "urls_scanned": {
+        "message": "URLs Scanned",
+        "description": "The text used to show how many URLs are scanned on the dashboard."
+    },
+    "unique_urls_scanned": {
+        "message": "Unique URLs Scanned",
+        "description": "The text used to show how many unique URLs are scanned on the dashboard."
+    },
+    "warning_header": {
+        "message": "THREATSLAYER ALERT!",
+        "description": "The text used in the warning banner."
+    },
+    "warning_text": {
+        "message": "This website may be malicious. Close this tab unless you know the site is safe.",
+        "description": "The text used in the warning banner."
+    }
+}

--- a/source/_locales/pt_PT/messages.json
+++ b/source/_locales/pt_PT/messages.json
@@ -1,0 +1,34 @@
+{
+    "appDesc": {
+        "message": "Proteção de grau empresarial gratuita para o seu navegador pessoal.",
+        "description": "The description of the extension, displayed in the user's browser."
+    },
+    "description": {
+        "message": "Free enterprise-grade security for your personal browser.",
+        "description": "The description in the manifest."
+    },
+    "malicious_sites_detected": {
+        "message": "Malicious Sites Detected",
+        "description": "The text used to show how many malicious URLs are scanned on the dashboard."
+    },
+    "popup_title": {
+        "message": "Threatslayer Active.",
+        "description": "The title used for the popup when the extension icon is pressed."
+    },
+    "urls_scanned": {
+        "message": "URLs Scanned",
+        "description": "The text used to show how many URLs are scanned on the dashboard."
+    },
+    "unique_urls_scanned": {
+        "message": "Unique URLs Scanned",
+        "description": "The text used to show how many unique URLs are scanned on the dashboard."
+    },
+    "warning_header": {
+        "message": "THREATSLAYER ALERT!",
+        "description": "The text used in the warning banner."
+    },
+    "warning_text": {
+        "message": "This website may be malicious. Close this tab unless you know the site is safe.",
+        "description": "The text used in the warning banner."
+    }
+}

--- a/source/_locales/zh_CN/messages.json
+++ b/source/_locales/zh_CN/messages.json
@@ -1,0 +1,34 @@
+{
+    "appDesc": {
+        "message": "免费的企业级个人浏览器保护。",
+        "description": "The description of the extension, displayed in the user's browser."
+    },
+    "description": {
+        "message": "Free enterprise-grade security for your personal browser.",
+        "description": "The description in the manifest."
+    },
+    "malicious_sites_detected": {
+        "message": "Malicious Sites Detected",
+        "description": "The text used to show how many malicious URLs are scanned on the dashboard."
+    },
+    "popup_title": {
+        "message": "Threatslayer Active.",
+        "description": "The title used for the popup when the extension icon is pressed."
+    },
+    "urls_scanned": {
+        "message": "URLs Scanned",
+        "description": "The text used to show how many URLs are scanned on the dashboard."
+    },
+    "unique_urls_scanned": {
+        "message": "Unique URLs Scanned",
+        "description": "The text used to show how many unique URLs are scanned on the dashboard."
+    },
+    "warning_header": {
+        "message": "THREATSLAYER ALERT!",
+        "description": "The text used in the warning banner."
+    },
+    "warning_text": {
+        "message": "This website may be malicious. Close this tab unless you know the site is safe.",
+        "description": "The text used in the warning banner."
+    }
+}


### PR DESCRIPTION
* AR: Arabic
* DE: German
* ES: Spanish
* FR: French
* HE: Hebrew
* HI: Hindi
* JA: Japanese
* KO: Korean
* pt_PT: Portugese-Portuguese
* zh_CN: Simplified Chinese